### PR TITLE
[FP-7] feature: 내 여행일정 페이지 추가

### DIFF
--- a/src/components/DaySummary/DaySummary.style.ts
+++ b/src/components/DaySummary/DaySummary.style.ts
@@ -2,12 +2,13 @@ import styled from "styled-components"
 
 export const DayHeader = styled.h1`
   font-weight: bold;
+  width: 60px;
   margin-right: 30px;
 `
 export const DestinationItem = styled.span`
   display: inline-flex;
   align-items: center;
-  font-size: 14px;
+  font-size: 10px;
 
   & + & {
     margin-left: 8px;

--- a/src/components/DaySummary/DaySummary.tsx
+++ b/src/components/DaySummary/DaySummary.tsx
@@ -14,7 +14,7 @@ interface DaySummaryProps {
 const DaySummary: React.FC<DaySummaryProps> = ({ selectedDay, destinations }) => {
   return (
     <Box display="flex">
-      <Card width="500px" borderRadius="30px" maxWidth="500px" maxHeight="70px">
+      <Card width="410px" mt="10px" borderRadius="30px" maxWidth="500px" maxHeight="60px">
         <CardBody display="flex" justifyContent="center">
           <DayHeader>{selectedDay}.</DayHeader>
           <DayDestination>
@@ -27,10 +27,6 @@ const DaySummary: React.FC<DaySummaryProps> = ({ selectedDay, destinations }) =>
           </DayDestination>
         </CardBody>
       </Card>
-
-      <Box ml="100px" display="flex" justifyContent="flex-end">
-        <Map />
-      </Box>
     </Box>
   )
 }

--- a/src/components/HorizontalCard/HorizontalCard.tsx
+++ b/src/components/HorizontalCard/HorizontalCard.tsx
@@ -13,7 +13,88 @@ const shareScheduleWithKakao = () => {
   console.log("카카오톡으로 일정 공유하기")
 }
 
-const HorizontalCard = () => {
+export const HorizontalCardContent = () => {
+  return (
+    <>
+      <Box display="flex" mt="20px" mb="20px">
+        <Image
+          src="https://plus.unsplash.com/premium_photo-1661963130289-aa70dd516940?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+          alt="광안대교사진"
+          width="260px"
+          ml="10px"
+          borderRadius="10px"
+        />
+
+        <Box>
+          <Box ml="20px" mt="20px">
+            <Box mt="-2" display="flex">
+              <Badge variant="subtle" colorScheme="green" minWidth="50px" mt="5">
+                2박 3일
+              </Badge>
+              <Text color="gray.500" fontSize="9px" ml="5px" mt="6">
+                2024.03.05 ~ 2024.03.07
+              </Text>
+            </Box>
+            <Heading
+              size="md"
+              mt="2"
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                maxWidth: "18ch" // 18글자를 넘어가면 잘라내고 "..." 표시
+              }}
+            >
+              OO이랑 떠나는 부산 여행
+            </Heading>
+            <Text color="gray.500" fontSize="11px" ml="5px" mt="1">
+              총 예상 경비 : 550,000원
+            </Text>
+            <Box mt="5">
+              <KakaoButton onClick={shareScheduleWithKakao}>카카오톡으로 일정 공유하기</KakaoButton>
+            </Box>
+            <TagBox>
+              <TagStyle>커플여행</TagStyle>
+              <TagStyle>관광</TagStyle>
+              <TagStyle>휴식</TagStyle>
+              <TagStyle>바다여행</TagStyle>
+            </TagBox>
+
+            <Box display="flex" justifyContent="flex-end">
+              <Box mt="5">
+                <Text textAlign="end" color="gray.500" fontSize="9px" mr="5px">
+                  UserNickName
+                </Text>
+                <Text textAlign="end" color="gray.500" fontSize="9px" mr="5px">
+                  2024.03.01 20:45작성
+                </Text>
+              </Box>
+              <Avatar border="2px solid white" size="md" name="Kent Dodds" src="https://bit.ly/kent-c-dodds" mt="2" />
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </>
+  )
+}
+
+export const ScheduleButtons = () => {
+  return (
+    <Box mt="6" display="flex">
+      <Box mr="2">
+        <Buttons text="수정" size="xs" />
+      </Box>
+      <Box mr="2">
+        <Buttons text="삭제" size="xs" />
+      </Box>
+      <Box mr="10">
+        <Buttons text="리뷰작성" size="xs" />
+      </Box>
+    </Box>
+  )
+}
+
+export const HorizontalCard = () => {
   return (
     <>
       <Card
@@ -23,78 +104,9 @@ const HorizontalCard = () => {
         overflow="hidden"
         variant="outline"
       >
-        <Box display="flex" mt="20px" mb="20px">
-          <Image
-            src="https://plus.unsplash.com/premium_photo-1661963130289-aa70dd516940?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-            alt="광안대교사진"
-            width="300px"
-            height="250px"
-            ml="30px"
-            mt="5"
-            borderRadius="10px"
-          />
-
-          <Box>
-            <CardBody ml="20px">
-              <Box mt="-2" display="flex" justifyContent="space-between">
-                <Badge variant="subtle" colorScheme="green" minWidth="50px" mt="5">
-                  2박 3일
-                </Badge>
-                <Text color="gray.500" fontSize="9px" ml="5px" mt="6">
-                  2024.03.05 ~ 2024.03.07
-                </Text>
-              </Box>
-              <Heading
-                size="md"
-                mt="2"
-                sx={{
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                  maxWidth: "18ch" // 18글자를 넘어가면 잘라내고 "..." 표시
-                }}
-              >
-                OO이랑 떠나는 부산 여행
-              </Heading>
-              <Text color="gray.500" fontSize="11px" ml="5px" mt="1">
-                총 예상 경비 : 550,000원
-              </Text>
-              <Box mt="5">
-                <KakaoButton onClick={shareScheduleWithKakao}>카카오톡으로 일정 공유하기</KakaoButton>
-              </Box>
-              <TagBox>
-                <TagStyle>커플여행</TagStyle>
-                <TagStyle>관광</TagStyle>
-                <TagStyle>휴식</TagStyle>
-                <TagStyle>바다여행</TagStyle>
-              </TagBox>
-            </CardBody>
-
-            <CardFooter display="flex" justifyContent="flex-end">
-              <Box mt="-6">
-                <Text textAlign="end" color="gray.500" fontSize="9px" mr="5px">
-                  UserNickName
-                </Text>
-                <Text textAlign="end" color="gray.500" fontSize="9px" mr="5px">
-                  2024.03.01 20:45작성
-                </Text>
-              </Box>
-              <Avatar border="2px solid white" size="md" name="Kent Dodds" src="https://bit.ly/kent-c-dodds" mt="-9" />
-            </CardFooter>
-          </Box>
-        </Box>
+        <HorizontalCardContent />
         {/* 게시자에게만 보이도록 로직 수정 */}
-        <Box mt="6" display="flex">
-          <Box mr="2">
-            <Buttons text="수정" size="xs" />
-          </Box>
-          <Box mr="2">
-            <Buttons text="삭제" size="xs" />
-          </Box>
-          <Box mr="10">
-            <Buttons text="리뷰작성" size="xs" />
-          </Box>
-        </Box>
+        <ScheduleButtons />
       </Card>
     </>
   )

--- a/src/components/switch/PubPrivSwitch.tsx
+++ b/src/components/switch/PubPrivSwitch.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react"
-import { IsOpenSwitchProps } from "@/components/switch/type"
+import { PubPrivSwitchProps } from "@/components/switch/type"
 import { Switch } from "@chakra-ui/react"
 
-const PubPrivSwitch: React.FC<IsOpenSwitchProps> = ({ ontext, offtext }) => {
+const PubPrivSwitch: React.FC<PubPrivSwitchProps> = ({ ontext, offtext }) => {
   const [isPublic, setIsPublic] = useState<boolean>(true)
 
   const toggleIsPublic = () => {

--- a/src/components/switch/type.d.ts
+++ b/src/components/switch/type.d.ts
@@ -1,4 +1,4 @@
-export interface IsOpenSwitchProps {
+export interface PubPrivSwitchProps {
   ontext: string
   offtext: string
 }

--- a/src/pages/MyFavoritePage/MyFavorite.style.ts
+++ b/src/pages/MyFavoritePage/MyFavorite.style.ts
@@ -15,7 +15,7 @@ export const FavoriteTitle = styled.div`
   width: 90%;
   text-align: left;
   font-family: "Noto Sans";
-  font-size: 1.5rem;
+  font-size: 1.3rem;
   font-weight: bold;
 `
 export const FavoriteList = styled.div``

--- a/src/pages/MyFavoritePage/MyFavorite.tsx
+++ b/src/pages/MyFavoritePage/MyFavorite.tsx
@@ -10,7 +10,7 @@ const MyFavorite = () => {
       <SideBar />
       <Favorite>
         <FavoriteTitle>
-          <CiStar size="2rem" />
+          <CiStar size="1.8rem" />
           일정 즐겨찾기 목록
         </FavoriteTitle>
         <FavoriteList>

--- a/src/pages/MySchedulePage/DetailSchedule.style.ts
+++ b/src/pages/MySchedulePage/DetailSchedule.style.ts
@@ -1,0 +1,15 @@
+import styled from "styled-components"
+
+export const DaySchedule = styled.div`
+  padding-left: 10px;
+  width: 450px;
+`
+export const ScheduleDetail = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  border: 1px solid lightgray;
+  margin-top: 1rem;
+  border-radius: 5px;
+`

--- a/src/pages/MySchedulePage/DetailSchedule.tsx
+++ b/src/pages/MySchedulePage/DetailSchedule.tsx
@@ -1,0 +1,29 @@
+import DaySummary from "@/components/DaySummary/DaySummary"
+import { HorizontalCardContent, ScheduleButtons } from "@/components/HorizontalCard/HorizontalCard"
+import { DaySchedule, ScheduleDetail } from "./DetailSchedule.style"
+import { Box } from "@chakra-ui/react"
+
+const DetailSchedule = () => {
+  const destinations = [
+    ["태종대", "해동용궁사", "감천문화마을", "부평깡통시장"],
+    ["태종대", "해동용궁사", "감천문화마을", "부평깡통시장"],
+    ["태종대", "해동용궁사", "감천문화마을", "부평깡통시장"]
+  ]
+  return (
+    <ScheduleDetail>
+      <HorizontalCardContent />
+      <DaySchedule>
+        {destinations.map((destination, index) => (
+          <Box key={index}>
+            <DaySummary selectedDay={`Day ${index + 1}`} destinations={destination} />
+          </Box>
+        ))}
+        <Box display="flex" justifyContent="flex-end">
+          <ScheduleButtons />
+        </Box>
+      </DaySchedule>
+    </ScheduleDetail>
+  )
+}
+
+export default DetailSchedule

--- a/src/pages/MySchedulePage/MySchedule.style.ts
+++ b/src/pages/MySchedulePage/MySchedule.style.ts
@@ -1,7 +1,37 @@
 import styled from "styled-components"
 
 export const Schedule = styled.div`
-  width: 80%;
+  width: 1024px;
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
+`
+
+export const ScheduleTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 3rem;
+  width: 90%;
+  font-size: 1.3rem;
+  font-weight: bold;
+`
+export const ScheduleText = styled.div`
+  display: flex;
+  align-items: center;
+  height: 2rem;
+`
+export const WholeScheduleButton = styled.button`
+  height: 2rem;
+  width: 5rem;
+  font-size: 0.7rem;
+  border: 1px solid lightgray;
+  border-radius: 0.5rem;
+`
+export const ScheduleList = styled.div`
+  margin-top: 30px;
+  margin-bottom: 30px;
+  display: flex;
+  width: 95%;
+  flex-direction: column;
 `

--- a/src/pages/MySchedulePage/MySchedule.tsx
+++ b/src/pages/MySchedulePage/MySchedule.tsx
@@ -1,12 +1,33 @@
 import SideBar from "@/components/sidebar/SideBar"
 import { MyPageWrapper } from "@/styles/styles"
-import { Schedule } from "@/pages/MySchedulePage/MySchedule.style"
+import {
+  Schedule,
+  ScheduleList,
+  ScheduleText,
+  ScheduleTitle,
+  WholeScheduleButton
+} from "@/pages/MySchedulePage/MySchedule.style"
+import { GrFormSchedule } from "react-icons/gr"
+import DetailSchedule from "./DetailSchedule"
 
 const MySchedule = () => {
   return (
     <MyPageWrapper>
       <SideBar />
-      <Schedule />
+      <Schedule>
+        <ScheduleTitle>
+          <ScheduleText>
+            <GrFormSchedule size="1.8rem" />
+            여행 일정 목록
+          </ScheduleText>
+          <WholeScheduleButton>전체 일정 관리</WholeScheduleButton>
+        </ScheduleTitle>
+        <ScheduleList>
+          <DetailSchedule />
+          <DetailSchedule />
+          <DetailSchedule />
+        </ScheduleList>
+      </Schedule>
     </MyPageWrapper>
   )
 }

--- a/src/pages/ScheduleDetailPage/ScheduleDetailPage.tsx
+++ b/src/pages/ScheduleDetailPage/ScheduleDetailPage.tsx
@@ -5,17 +5,21 @@ import { Card, CardBody, CardHeader } from "@chakra-ui/card"
 import { Box, Text } from "@chakra-ui/layout"
 import { Editable, EditablePreview, EditableTextarea } from "@chakra-ui/editable"
 import { IndexStyle, ScheduleDetailStyle } from "./ScheduleDetailPage.style"
+import Map from "@/components/Map/Map"
 
 const destinations = ["태종대", "해동용궁사", "감천문화마을", "부평깡통시장"]
+
 const ScheduleDetailPage = () => {
   return (
     <Box ml="180px" mb="30px">
       <HorizontalCard />
       <DayTab destinations={destinations} />
-
+      <Box ml="100px" display="flex" justifyContent="flex-end">
+        <Map />
+      </Box>
       <ScheduleDetailStyle>
         {destinations.map((destination, index) => (
-          <Box width="500px" mt="30px" key={index}>
+          <Box width="500px" mt="10px" key={index}>
             <Card fontSize="15px" fontWeight="bold">
               <CardHeader display="flex" justifyContent="space-between">
                 <Box display="flex">


### PR DESCRIPTION
## 🔧관련 이슈
  

## 📝작업 사항

> 마이페이지 하위의 '내 여행일정 페이지' 추가
> 

### 관련 스크린샷

<img width="1299" alt="image" src="https://github.com/dogfoot-birdfoot/footprint-front/assets/86706630/9a86f0e3-5625-47e5-b7a8-855f2f65c1e9">


## 👷기타(리뷰 요청 및 문제점)

> HorizontalCard에서 Card 부분과 Content 부분 나눴습니다.

> HorizontalCard 그대로 활용하려고 width 조절했습니다.
