### PR TITLE
[FP-22] refactor: 일정 생성 페이지 리팩토링 및 일정마다 선택한 장소 검색창에 표기, 카카오맵 지도 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=b5ccd3b8e030d7f4483e2755f25b0552"
+    ></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />

--- a/src/pages/CreateSchedulePage/AddSchedule.tsx
+++ b/src/pages/CreateSchedulePage/AddSchedule.tsx
@@ -5,10 +5,11 @@ import { FiChevronDown } from "react-icons/fi"
 import { format } from "date-fns"
 import { ko } from "date-fns/locale"
 import { useRecoilValue } from "recoil"
-import { selectedPlacesState } from "./selectedPlaceState"
 
 export interface AddScheduleProps {
   dates: Date[] // 날짜 배열
+  selectedPlaces: string[]
+  setSelectedPlaces: React.Dispatch<React.SetStateAction<string[]>>
   showSearchBox: boolean // SearchBox 표시 여부
   setShowSearchBox: React.Dispatch<React.SetStateAction<boolean>> // SearchBox 표시 여부를 설정하는 함수
 }
@@ -19,8 +20,13 @@ const formatDate = (date: Date) => {
   return format(date, "M월 d일 (EEE)", { locale: ko })
 }
 
-const AddSchedule: React.FC<AddScheduleProps> = ({ dates, showSearchBox, setShowSearchBox }) => {
-  const selectedPlaces = useRecoilValue(selectedPlacesState)
+const AddSchedule: React.FC<AddScheduleProps> = ({
+  dates,
+  selectedPlaces,
+  setSelectedPlaces,
+  showSearchBox,
+  setShowSearchBox
+}) => {
   const [placesByDate, setPlacesByDate] = useState<Record<number, string[]>>({})
   const [activeDateIndex, setActiveDateIndex] = useState<number | null>(null)
 
@@ -32,12 +38,14 @@ const AddSchedule: React.FC<AddScheduleProps> = ({ dates, showSearchBox, setShow
 
   // SearchBox가 닫히고, 현재 활성화된 날짜가 있을 때 해당 날짜에 대한 장소들 업데이트
   useEffect(() => {
-    if (!showSearchBox && activeDateIndex !== null) {
+    console.log(selectedPlaces)
+    if (activeDateIndex !== null) {
       setPlacesByDate(prev => ({
         ...prev,
         [activeDateIndex]: selectedPlaces
       }))
     }
+    // setSelectedPlaces([]) // 값 초기화
   }, [showSearchBox, activeDateIndex, selectedPlaces])
 
   return (

--- a/src/pages/CreateSchedulePage/AddSchedule.tsx
+++ b/src/pages/CreateSchedulePage/AddSchedule.tsx
@@ -4,15 +4,7 @@ import { IndexStyle } from "../ScheduleDetailPage/ScheduleDetailPage.style"
 import { FiChevronDown } from "react-icons/fi"
 import { format } from "date-fns"
 import { ko } from "date-fns/locale"
-import { useRecoilValue } from "recoil"
-
-export interface AddScheduleProps {
-  dates: Date[] // 날짜 배열
-  selectedPlaces: string[]
-  setSelectedPlaces: React.Dispatch<React.SetStateAction<string[]>>
-  showSearchBox: boolean // SearchBox 표시 여부
-  setShowSearchBox: React.Dispatch<React.SetStateAction<boolean>> // SearchBox 표시 여부를 설정하는 함수
-}
+import { AddScheduleProps } from "./type"
 
 // 날짜 포맷 함수
 const formatDate = (date: Date) => {
@@ -22,31 +14,35 @@ const formatDate = (date: Date) => {
 
 const AddSchedule: React.FC<AddScheduleProps> = ({
   dates,
+  setSelectedResults,
   selectedPlaces,
-  setSelectedPlaces,
+  placesByDate,
+  setPlacesByDate,
   showSearchBox,
   setShowSearchBox
 }) => {
-  const [placesByDate, setPlacesByDate] = useState<Record<number, string[]>>({})
-  const [activeDateIndex, setActiveDateIndex] = useState<number | null>(null)
-
   // "장소 추가" 버튼 클릭 핸들러, 날짜 인덱스를 인자로 받음
   const handleAddPlaceClick = (dateIndex: number) => {
-    setActiveDateIndex(dateIndex) // 현재 활성화된 날짜 인덱스 설정
-    setShowSearchBox(!showSearchBox) // SearchBox 표시 토글
+    if (showSearchBox === -1 || (showSearchBox !== -1 && dateIndex !== showSearchBox)) {
+      // SearchBox 비활성화 시 or 다른 일정 검색창 활성화
+      setShowSearchBox(dateIndex)
+      setSelectedResults(placesByDate[dateIndex] ? placesByDate[dateIndex] : [])
+    } else if (dateIndex == showSearchBox) {
+      // 같은 일정의 장소추가 버튼을 누르면 닫음(값 초기화)
+      setShowSearchBox(-1)
+      setSelectedResults([])
+    }
   }
 
   // SearchBox가 닫히고, 현재 활성화된 날짜가 있을 때 해당 날짜에 대한 장소들 업데이트
   useEffect(() => {
-    console.log(selectedPlaces)
-    if (activeDateIndex !== null) {
+    if (showSearchBox !== -1) {
       setPlacesByDate(prev => ({
         ...prev,
-        [activeDateIndex]: selectedPlaces
+        [showSearchBox]: selectedPlaces
       }))
     }
-    // setSelectedPlaces([]) // 값 초기화
-  }, [showSearchBox, activeDateIndex, selectedPlaces])
+  }, [selectedPlaces])
 
   return (
     <>

--- a/src/pages/CreateSchedulePage/CreateScheduleForm.tsx
+++ b/src/pages/CreateSchedulePage/CreateScheduleForm.tsx
@@ -5,20 +5,16 @@ import AddDestination from "./AddDestination"
 import Calendar from "./Calendar"
 import AddSchedule from "./AddSchedule"
 import AddPost from "./AddPost"
-
-export interface CreateScheduleFormProps {
-  selectedDates: Date[]
-  setSelectedDates: React.Dispatch<React.SetStateAction<Date[]>>
-  showSearchBox: boolean // 부모 컴포넌트로부터 전달받을 새로운 prop
-  setShowSearchBox: React.Dispatch<React.SetStateAction<boolean>> // 부모 컴포넌트로부터 전달받을 새로운 prop
-}
+import { CreateScheduleFormProps } from "./type"
 
 const CreateScheduleForm: React.FC<CreateScheduleFormProps> = ({
-  selectedDates,
-  setSelectedDates,
+  selectedPlaces,
+  setSelectedPlaces,
   showSearchBox,
   setShowSearchBox
 }) => {
+  const [selectedDates, setSelectedDates] = useState<Date[]>([]) // selectedDates 상태 끌어올리기
+
   const [isDestinationBoxVisible, setIsDestinationBoxVisible] = useState(false)
   const [isCalendarBoxVisible, setIsCalendarBoxVisible] = useState(false)
   const [isScheduleBoxVisible, setIsScheduleBoxVisible] = useState(false)
@@ -82,7 +78,13 @@ const CreateScheduleForm: React.FC<CreateScheduleFormProps> = ({
           {isScheduleBoxVisible && (
             <Card mt="10px">
               <CardBody>
-                <AddSchedule dates={selectedDates} showSearchBox={showSearchBox} setShowSearchBox={setShowSearchBox} />
+                <AddSchedule
+                  dates={selectedDates}
+                  selectedPlaces={selectedPlaces}
+                  setSelectedPlaces={setSelectedPlaces}
+                  showSearchBox={showSearchBox}
+                  setShowSearchBox={setShowSearchBox}
+                />
               </CardBody>
             </Card>
           )}

--- a/src/pages/CreateSchedulePage/CreateScheduleForm.tsx
+++ b/src/pages/CreateSchedulePage/CreateScheduleForm.tsx
@@ -5,24 +5,25 @@ import AddDestination from "./AddDestination"
 import Calendar from "./Calendar"
 import AddSchedule from "./AddSchedule"
 import AddPost from "./AddPost"
-import { CreateScheduleFormProps } from "./type"
+import SearchBox from "./SearchBox"
 
-const CreateScheduleForm: React.FC<CreateScheduleFormProps> = ({
-  selectedPlaces,
-  setSelectedPlaces,
-  showSearchBox,
-  setShowSearchBox
-}) => {
+const CreateScheduleForm: React.FC = ({}) => {
+  // List
   const [selectedDates, setSelectedDates] = useState<Date[]>([]) // selectedDates 상태 끌어올리기
-
-  const [isDestinationBoxVisible, setIsDestinationBoxVisible] = useState(false)
-  const [isCalendarBoxVisible, setIsCalendarBoxVisible] = useState(false)
-  const [isScheduleBoxVisible, setIsScheduleBoxVisible] = useState(false)
-  const [isPostBoxVisible, setIsPostBoxVisible] = useState(false)
+  const [placesByDate, setPlacesByDate] = useState<Record<number, string[]>>({}) // 일정별로 선택한 장소
+  const [selectedPlaces, setSelectedPlaces] = useState<string[]>([]) // 선택이 확정된 장소
+  const [selectedResults, setSelectedResults] = useState<string[]>([]) // 검색창에 체크된 장소
 
   const updateSelectedDates = (dates: Date[]) => {
     setSelectedDates(dates)
   }
+
+  // Boolean
+  const [showSearchBox, setShowSearchBox] = useState<number>(-1) // 비활성화 : -1, 활성화 : >0
+  const [isDestinationBoxVisible, setIsDestinationBoxVisible] = useState(false)
+  const [isCalendarBoxVisible, setIsCalendarBoxVisible] = useState(false)
+  const [isScheduleBoxVisible, setIsScheduleBoxVisible] = useState(false)
+  const [isPostBoxVisible, setIsPostBoxVisible] = useState(false)
 
   const DestinationToggleBox = () => {
     setIsDestinationBoxVisible(!isDestinationBoxVisible)
@@ -36,6 +37,7 @@ const CreateScheduleForm: React.FC<CreateScheduleFormProps> = ({
   const PostToggleBox = () => {
     setIsPostBoxVisible(!isPostBoxVisible)
   }
+
   return (
     <>
       <>
@@ -80,8 +82,10 @@ const CreateScheduleForm: React.FC<CreateScheduleFormProps> = ({
               <CardBody>
                 <AddSchedule
                   dates={selectedDates}
+                  setSelectedResults={setSelectedResults}
                   selectedPlaces={selectedPlaces}
-                  setSelectedPlaces={setSelectedPlaces}
+                  placesByDate={placesByDate}
+                  setPlacesByDate={setPlacesByDate}
                   showSearchBox={showSearchBox}
                   setShowSearchBox={setShowSearchBox}
                 />
@@ -102,6 +106,17 @@ const CreateScheduleForm: React.FC<CreateScheduleFormProps> = ({
             </Card>
           )}
         </Box>
+
+        {/* SearchBox 표기 부분 */}
+        {showSearchBox >= 0 && (
+          <Box width="550px" height="450px" mt="100px" ml="50px" position="sticky" top="100px">
+            <SearchBox
+              setSelectedPlaces={setSelectedPlaces}
+              selectedResults={selectedResults}
+              setSelectedResults={setSelectedResults}
+            />
+          </Box>
+        )}
       </>
     </>
   )

--- a/src/pages/CreateSchedulePage/CreateScheduleForm.tsx
+++ b/src/pages/CreateSchedulePage/CreateScheduleForm.tsx
@@ -6,6 +6,7 @@ import Calendar from "./Calendar"
 import AddSchedule from "./AddSchedule"
 import AddPost from "./AddPost"
 import SearchBox from "./SearchBox"
+import RouteMap from "./RouteMap"
 
 const CreateScheduleForm: React.FC = ({}) => {
   // List
@@ -117,6 +118,9 @@ const CreateScheduleForm: React.FC = ({}) => {
             />
           </Box>
         )}
+
+        {/* Map 표기 부분 */}
+        {showSearchBox < 0 && <RouteMap />}
       </>
     </>
   )

--- a/src/pages/CreateSchedulePage/CreateSchedulePage.tsx
+++ b/src/pages/CreateSchedulePage/CreateSchedulePage.tsx
@@ -1,28 +1,14 @@
-import React, { useState } from "react"
+import React from "react"
 import CreateScheduleForm from "@/pages/CreateSchedulePage/CreateScheduleForm"
 import { Box } from "@chakra-ui/react"
 import Buttons from "@/components/Buttons/Buttons"
-import SearchBox from "./SearchBox"
 
 const CreateSchedulePage: React.FC = () => {
-  const [selectedPlaces, setSelectedPlaces] = useState<string[]>([])
-  const [showSearchBox, setShowSearchBox] = useState(false)
-
   return (
     <>
       <Box mb="50px">
         <Box display="flex" justifyContent="space-between">
-          <CreateScheduleForm
-            selectedPlaces={selectedPlaces}
-            setSelectedPlaces={setSelectedPlaces}
-            showSearchBox={showSearchBox}
-            setShowSearchBox={setShowSearchBox}
-          />
-          {showSearchBox && (
-            <Box width="550px" height="450px" mt="100px" ml="50px" position="sticky" top="100px">
-              <SearchBox setSelectedPlaces={setSelectedPlaces} />
-            </Box>
-          )}
+          <CreateScheduleForm />
           <Box mt="30px">
             <Buttons size="sm" text="임시저장" />
           </Box>

--- a/src/pages/CreateSchedulePage/CreateSchedulePage.tsx
+++ b/src/pages/CreateSchedulePage/CreateSchedulePage.tsx
@@ -5,22 +5,22 @@ import Buttons from "@/components/Buttons/Buttons"
 import SearchBox from "./SearchBox"
 
 const CreateSchedulePage: React.FC = () => {
+  const [selectedPlaces, setSelectedPlaces] = useState<string[]>([])
   const [showSearchBox, setShowSearchBox] = useState(false)
-  const [selectedDates, setSelectedDates] = useState<Date[]>([]) // selectedDates 상태 끌어올리기
 
   return (
     <>
       <Box mb="50px">
         <Box display="flex" justifyContent="space-between">
           <CreateScheduleForm
-            selectedDates={selectedDates}
-            setSelectedDates={setSelectedDates}
+            selectedPlaces={selectedPlaces}
+            setSelectedPlaces={setSelectedPlaces}
             showSearchBox={showSearchBox}
             setShowSearchBox={setShowSearchBox}
           />
           {showSearchBox && (
             <Box width="550px" height="450px" mt="100px" ml="50px" position="sticky" top="100px">
-              <SearchBox />
+              <SearchBox setSelectedPlaces={setSelectedPlaces} />
             </Box>
           )}
           <Box mt="30px">

--- a/src/pages/CreateSchedulePage/RouteMap.tsx
+++ b/src/pages/CreateSchedulePage/RouteMap.tsx
@@ -33,6 +33,9 @@ function RouteMap() {
     ]
 
     const linePositions = []
+    // 인포윈도우에 표출될 내용으로 HTML 문자열이나 document element가 가능합니다
+
+    // 인포윈도우를 생성합니다
 
     for (let i = 0; i < positions.length; i++) {
       // 표기할 선 위치
@@ -42,18 +45,25 @@ function RouteMap() {
       const marker = new kakao.maps.Marker({
         map: map,
         title: positions[i].title,
-        text: "Hello",
         position: positions[i].latlng
+      })
+
+      // InfoWindow 표시
+      const infowindow = new kakao.maps.InfoWindow({
+        map: map,
+        position: positions[i].latlng,
+        content: `<div style="width:100px; text-align:center;">` + positions[i].title + `</div>`
       })
     }
 
+    // 경로 표기
     const polyline = new kakao.maps.Polyline({
       map: map,
-      path: linePositions, // 선을 구성하는 좌표배열 입니다
-      strokeWeight: 4, // 선의 두께 입니다
-      strokeColor: "#10bbd5", // 선의 색깔입니다
-      strokeOpacity: 0.7, // 선의 불투명도 입니다 1에서 0 사이의 값이며 0에 가까울수록 투명합니다
-      strokeStyle: "solid" // 선의 스타일입니다
+      path: linePositions, // 선을 구성하는 좌표배열
+      strokeWeight: 4,
+      strokeColor: "#10bbd5",
+      strokeOpacity: 0.7,
+      strokeStyle: "solid"
     })
   }, [])
 

--- a/src/pages/CreateSchedulePage/RouteMap.tsx
+++ b/src/pages/CreateSchedulePage/RouteMap.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from "react"
+import { Box, Button } from "@chakra-ui/react"
+
+function RouteMap() {
+  const { kakao } = window
+
+  useEffect(() => {
+    const mapContainer = document.getElementById("mapContainer") // 지도를 표시할 div
+    const options = {
+      center: new kakao.maps.LatLng(33.438201, 126.578667), // 지도의 중심좌표
+      level: 5 // 지도의 확대 레벨
+    }
+
+    const map = new kakao.maps.Map(mapContainer, options) // 지도 표기
+
+    const positions = [
+      {
+        title: "좌표 1",
+        latlng: new kakao.maps.LatLng(33.444101, 126.570337)
+      },
+      {
+        title: "좌표 2",
+        latlng: new kakao.maps.LatLng(33.431101, 126.571337)
+      },
+      {
+        title: "좌표 3",
+        latlng: new kakao.maps.LatLng(33.443101, 126.581337)
+      },
+      {
+        title: "좌표 4",
+        latlng: new kakao.maps.LatLng(33.442101, 126.583337)
+      }
+    ]
+
+    const linePositions = []
+
+    for (let i = 0; i < positions.length; i++) {
+      // 표기할 선 위치
+      linePositions.push(positions[i].latlng)
+
+      // 마커 표기
+      const marker = new kakao.maps.Marker({
+        map: map,
+        title: positions[i].title,
+        text: "Hello",
+        position: positions[i].latlng
+      })
+    }
+
+    const polyline = new kakao.maps.Polyline({
+      map: map,
+      path: linePositions, // 선을 구성하는 좌표배열 입니다
+      strokeWeight: 4, // 선의 두께 입니다
+      strokeColor: "#10bbd5", // 선의 색깔입니다
+      strokeOpacity: 0.7, // 선의 불투명도 입니다 1에서 0 사이의 값이며 0에 가까울수록 투명합니다
+      strokeStyle: "solid" // 선의 스타일입니다
+    })
+  }, [])
+
+  return (
+    <Box width="550px" height="450px" mt="100px" ml="50px" position="sticky" top="100px">
+      <Box id="mapContainer" width="550px" height="450px"></Box>
+    </Box>
+  )
+}
+
+export default RouteMap

--- a/src/pages/CreateSchedulePage/SearchBox.tsx
+++ b/src/pages/CreateSchedulePage/SearchBox.tsx
@@ -15,8 +15,6 @@ import {
   Button
 } from "@chakra-ui/react"
 import { IconStyle } from "@/components/NavBar/SearchBar.style"
-import { useSetRecoilState } from "recoil"
-import { selectedPlacesState } from "./selectedPlaceState"
 import { SearchBoxProps } from "./type"
 
 // 예시로 사용할 모의 한국 지역 및 여행지 데이터
@@ -40,11 +38,10 @@ const mockLocations = [
   "동대문 디자인 플라자"
 ]
 
-const SearchBox: React.FC<SearchBoxProps> = ({ setSelectedPlaces }) => {
+const SearchBox: React.FC<SearchBoxProps> = ({ setSelectedPlaces, selectedResults, setSelectedResults }) => {
   // 리코일 사용해서 상태를 관리해줌 (너무 여기저기 컴포넌트를 거쳐야해서 리코일이 간편함)
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<string[]>(mockLocations)
-  const [selectedResults, setSelectedResults] = useState<string[]>([])
 
   const handleAddPlaces = () => {
     // 선택된 장소들을 리코일 상태에 업데이트
@@ -111,7 +108,7 @@ const SearchBox: React.FC<SearchBoxProps> = ({ setSelectedPlaces }) => {
           height="40px"
           onClick={handleAddPlaces}
         >
-          장소확정
+          선택 완료
         </Button>
       </Box>
     </Card>

--- a/src/pages/CreateSchedulePage/SearchBox.tsx
+++ b/src/pages/CreateSchedulePage/SearchBox.tsx
@@ -17,6 +17,7 @@ import {
 import { IconStyle } from "@/components/NavBar/SearchBar.style"
 import { useSetRecoilState } from "recoil"
 import { selectedPlacesState } from "./selectedPlaceState"
+import { SearchBoxProps } from "./type"
 
 // 예시로 사용할 모의 한국 지역 및 여행지 데이터
 const mockLocations = [
@@ -39,11 +40,10 @@ const mockLocations = [
   "동대문 디자인 플라자"
 ]
 
-const SearchBox: React.FC = () => {
+const SearchBox: React.FC<SearchBoxProps> = ({ setSelectedPlaces }) => {
   // 리코일 사용해서 상태를 관리해줌 (너무 여기저기 컴포넌트를 거쳐야해서 리코일이 간편함)
-  const setSelectedPlaces = useSetRecoilState(selectedPlacesState)
   const [query, setQuery] = useState("")
-  const [results, setResults] = useState<string[]>([])
+  const [results, setResults] = useState<string[]>(mockLocations)
   const [selectedResults, setSelectedResults] = useState<string[]>([])
 
   const handleAddPlaces = () => {

--- a/src/pages/CreateSchedulePage/type.d.ts
+++ b/src/pages/CreateSchedulePage/type.d.ts
@@ -1,10 +1,15 @@
-export interface CreateScheduleFormProps {
-  selectedPlaces: string[]
-  setSelectedPlaces: React.Dispatch<React.SetStateAction<string[]>>
-  showSearchBox: boolean // 부모 컴포넌트로부터 전달받을 새로운 prop
-  setShowSearchBox: React.Dispatch<React.SetStateAction<boolean>> // 부모 컴포넌트로부터 전달받을 새로운 prop
-}
-
 export interface SearchBoxProps {
   setSelectedPlaces: React.Dispatch<React.SetStateAction<string[]>>
+  selectedResults: string[]
+  setSelectedResults: React.Dispatch<React.SetStateAction<string[]>>
+}
+
+export interface AddScheduleProps {
+  dates: Date[] // 날짜 배열
+  setSelectedResults: React.Dispatch<React.SetStateAction<string[]>>
+  selectedPlaces: string[]
+  placesByDate: Record<number, string[]>
+  setPlacesByDate: React.Dispatch<React.SetStateAction<Record<number, string[]>>>
+  showSearchBox: number // SearchBox 표시 여부
+  setShowSearchBox: React.Dispatch<React.SetStateAction<number>> // SearchBox 표시 여부를 설정하는 함수
 }

--- a/src/pages/CreateSchedulePage/type.d.ts
+++ b/src/pages/CreateSchedulePage/type.d.ts
@@ -1,0 +1,10 @@
+export interface CreateScheduleFormProps {
+  selectedPlaces: string[]
+  setSelectedPlaces: React.Dispatch<React.SetStateAction<string[]>>
+  showSearchBox: boolean // 부모 컴포넌트로부터 전달받을 새로운 prop
+  setShowSearchBox: React.Dispatch<React.SetStateAction<boolean>> // 부모 컴포넌트로부터 전달받을 새로운 prop
+}
+
+export interface SearchBoxProps {
+  setSelectedPlaces: React.Dispatch<React.SetStateAction<string[]>>
+}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="react-scripts" />
+
+interface Window {
+  kakao: any
+}


### PR DESCRIPTION
## 🔧관련 이슈

## 📝작업 사항

> 일정 생성 페이지 리팩토링
>- SearchBox 위치 이동 : CreateSchedulePage -> CreateScheduleForm 이동)
>- showSearchBox : boolean -> number로 state 변경
>-> -1은 표기하지 않음, 0이상의 index 값이 설정 되면 searchBox 표기
>- Recoil이 필요한 state -> Props 전달로 변경

> 일정마다 선택한 장소 검색창에 표기

### 관련 스크린샷

<img width="1248" alt="image" src="https://github.com/dogfoot-birdfoot/footprint-front/assets/86706630/d245e578-b659-4d6c-a35f-fd67ee768f41">
<img width="1246" alt="image" src="https://github.com/dogfoot-birdfoot/footprint-front/assets/86706630/d57e5d04-d027-4dc1-9d8d-7e95af7f1655">
<img width="1338" alt="image" src="https://github.com/dogfoot-birdfoot/footprint-front/assets/86706630/ac81112c-6074-49a2-9a8f-d2c42495415a">
<img width="1338" alt="image" src="https://github.com/dogfoot-birdfoot/footprint-front/assets/86706630/d88a5e46-3748-458d-856c-b0653c360ba8">






## 👷기타(리뷰 요청 및 문제점)

> ex) 파일명을 A에서 B로 수정했는데, 확인 부탁드립니다.
