### PR TITLE
feat: 일정 공유 페이지에서 스크롤로 다음 카드 불러오는 기능

### DIFF
--- a/src/components/DropDownButton/DropDownButton.tsx
+++ b/src/components/DropDownButton/DropDownButton.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Box, Menu, MenuButton, MenuList } from "@chakra-ui/react"
+import { Box, Menu, MenuButton, MenuItem, MenuItemOption, MenuList } from "@chakra-ui/react"
 import { FiChevronDown, FiChevronUp } from "react-icons/fi"
 import { MenuTitle, StyledMenuItem } from "@/components/DropDownButton/DropDown.style"
 
@@ -8,7 +8,7 @@ import { Link } from "react-router-dom"
 
 const DropDownButton: React.FC<DropDownButtonProps> = ({ title, contents }) => {
   return (
-    <Menu isLazy>
+    <Menu isLazy closeOnSelect={true}>
       {({ isOpen }) => (
         <>
           <MenuButton>
@@ -23,7 +23,9 @@ const DropDownButton: React.FC<DropDownButtonProps> = ({ title, contents }) => {
             {contents.map((item, index) => (
               <Box key={index}>
                 <Link to={`/${item[1]}`}>
-                  <StyledMenuItem href="#">{item[0]}</StyledMenuItem>
+                  <MenuItem margin="0" padding="0">
+                    <StyledMenuItem href="#">{item[0]}</StyledMenuItem>
+                  </MenuItem>
                 </Link>
               </Box>
             ))}

--- a/src/components/card/CardItem.tsx
+++ b/src/components/card/CardItem.tsx
@@ -9,7 +9,7 @@ const CardItem = () => {
 
   return (
     <>
-      <Card maxW="xs" marginLeft="10px">
+      <Card maxW="xs" width="310px" marginLeft="10px">
         <CardBody>
           <Box display="flex" justifyContent="center">
             <ImageContainer>
@@ -17,7 +17,7 @@ const CardItem = () => {
                 src="https://images.unsplash.com/photo-1676705909846-2d6183d8bc1e?q=80&w=1335&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
                 alt="강원도 산 사진"
                 borderRadius="lg"
-                width={"330px"}
+                width={"280px"}
                 height={"160px"}
               />
               <PositionedAvatar>

--- a/src/pages/ScheduleSharePage/ScheduleSharePage.tsx
+++ b/src/pages/ScheduleSharePage/ScheduleSharePage.tsx
@@ -30,16 +30,19 @@ const ScheduleSharePage = () => {
   function addCards() {
     setCardLists(cardLists => [
       ...cardLists,
-      ["/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail"]
+      Array(4).fill("/schedule_share_detail"),
+      Array(4).fill("/schedule_share_detail")
     ])
   }
 
   useEffect(() => {
     if (target.current) {
+      // cardList에 받아올 값이 더 존재한다면 observe.
       observe(target.current)
     }
 
     if (target.current && cardLists.length === 30) {
+      // 서버에서 cardList에 받아올 값이 더 없다면 unobserve.
       unobserve(target.current)
     }
   }, [cardLists])

--- a/src/pages/ScheduleSharePage/ScheduleSharePage.tsx
+++ b/src/pages/ScheduleSharePage/ScheduleSharePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import CardItem from "@/components/Card/CardItem"
 import { CardListBox } from "@/pages/MainPage/MainPage.style"
 import { Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/menu"
@@ -7,13 +7,42 @@ import { Button } from "@chakra-ui/button"
 
 import { SortButton } from "@/pages/ScheduleSharePage/ScheduleSharePage.style"
 import { Link } from "react-router-dom"
+import { Box } from "@chakra-ui/react"
+import useIntersectionObserver from "./useIntersectionObserver"
 
 const ScheduleSharePage = () => {
   const [selectedItem, setSelectedItem] = useState("전국") // 초기 상태를 '전국'으로 설정
 
+  // 카드에 대한 상태 저장
+  const [cardLists, setCardLists] = useState<string[][]>([
+    ["/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail"],
+    ["/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail"],
+    ["/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail"]
+  ])
+
+  const target = useRef(null)
+  const [observe, unobserve] = useIntersectionObserver(addCards)
+
   const handleMenuItemClick = (itemName: React.SetStateAction<string>) => {
     setSelectedItem(itemName) // 메뉴 아이템 클릭 시 상태 업데이트
   }
+
+  function addCards() {
+    setCardLists(cardLists => [
+      ...cardLists,
+      ["/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail", "/schedule_share_detail"]
+    ])
+  }
+
+  useEffect(() => {
+    if (target.current) {
+      observe(target.current)
+    }
+
+    if (target.current && cardLists.length === 30) {
+      unobserve(target.current)
+    }
+  }, [cardLists])
 
   return (
     <>
@@ -32,22 +61,21 @@ const ScheduleSharePage = () => {
           <MenuItem onClick={() => handleMenuItemClick("경주")}>경주</MenuItem>
         </MenuList>
       </Menu>
-      <CardListBox>
-        {/* 나중에는 링크를 동적으로 받아와야함 */}
-        <Link to="/schedule_share_detail">
-          <CardItem />
-        </Link>
-        <CardItem />
-        <CardItem />
-        <CardItem />
-      </CardListBox>
 
-      <CardListBox>
-        <CardItem />
-        <CardItem />
-        <CardItem />
-        <CardItem />
-      </CardListBox>
+      {/* cardList 출력 */}
+      {cardLists.map((cardList, index) => (
+        <CardListBox key={index}>
+          {cardList.map((item, idx) => (
+            <Link key={idx} to={item}>
+              <CardItem />
+            </Link>
+          ))}
+        </CardListBox>
+      ))}
+
+      <Box ref={target} width="100%" display="flex" justifyContent={"center"} border="1px solid black">
+        요소가 보이면 callback 함수 호출
+      </Box>
     </>
   )
 }

--- a/src/pages/ScheduleSharePage/useIntersectionObserver.tsx
+++ b/src/pages/ScheduleSharePage/useIntersectionObserver.tsx
@@ -1,0 +1,24 @@
+import { useRef } from "react"
+
+export default function useIntersectionObserver(callback: any) {
+  const observer = useRef(
+    new IntersectionObserver(
+      (entries, observer) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            callback()
+          }
+        })
+      },
+      { threshold: 1 }
+    )
+  )
+  const observe = (element: Element) => {
+    observer.current.observe(element)
+  }
+  const unobserve = (element: HTMLElement) => {
+    observer.current.unobserve(element)
+  }
+
+  return [observe, unobserve]
+}


### PR DESCRIPTION
## 🔧관련 이슈
  

## 📝작업 사항

> 일정 공유 페이지에서 스크롤로 다음 카드 불러오는 기능
> navBar 내에 MenuItem 추가하여, closeOnSelect 작동 처리

### 관련 스크린샷


## 👷기타(리뷰 요청 및 문제점)

>
